### PR TITLE
fix(txtop): prevent panic on closed channel by isolating per-connection error channels

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,14 +230,6 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 	// it and cause a "send on closed channel" panic on the next connection.
 	// Instead give each connection its own channel and relay errors out.
 	connErrorChan := make(chan error, 10)
-	go func() {
-		for err := range connErrorChan {
-			select {
-			case errorChan <- err:
-			default:
-			}
-		}
-	}()
 	oConn, err := ouroboros.NewConnection(
 		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
 		ouroboros.WithErrorChan(connErrorChan),
@@ -293,6 +285,14 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 			return nil, errors.New("specify either the UNIX socket path or the address/port")
 		}
 		slog.Info("Successfully connected to node")
+		go func() {
+			for err := range connErrorChan {
+				select {
+				case errorChan <- err:
+				default:
+				}
+			}
+		}()
 		return oConn, nil
 	}
 	return nil, fmt.Errorf(

--- a/main.go
+++ b/main.go
@@ -225,9 +225,22 @@ func (c *Config) populateNetworkMagic() error {
 
 func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 	cfg := GetConfig()
+	// gouroboros closes the error channel it's given during shutdown, so we
+	// must never hand it the shared errorChan directly — doing so would close
+	// it and cause a "send on closed channel" panic on the next connection.
+	// Instead give each connection its own channel and relay errors out.
+	connErrorChan := make(chan error, 10)
+	go func() {
+		for err := range connErrorChan {
+			select {
+			case errorChan <- err:
+			default:
+			}
+		}
+	}()
 	oConn, err := ouroboros.NewConnection(
 		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
-		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithErrorChan(connErrorChan),
 		ouroboros.WithNodeToNode(false),
 		ouroboros.WithKeepAlive(true),
 	)
@@ -559,6 +572,7 @@ func initializeData(errorChan chan error) {
 			GetSizes(oConn),
 			GetTransactions(oConn),
 		))
+		oConn.Close()
 	}
 }
 
@@ -673,6 +687,7 @@ func startRefreshLoop(cfg *Config, errorChan chan error) {
 						GetSizes(oConn),
 						GetTransactions(oConn),
 					)
+					oConn.Close()
 					if tmpText != "" && tmpText != content {
 						content = tmpText
 						text.Clear()

--- a/main.go
+++ b/main.go
@@ -287,10 +287,7 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 		slog.Info("Successfully connected to node")
 		go func() {
 			for err := range connErrorChan {
-				select {
-				case errorChan <- err:
-				default:
-				}
+				errorChan <- err
 			}
 		}()
 		return oConn, nil

--- a/main_test.go
+++ b/main_test.go
@@ -205,7 +205,7 @@ func TestTogglePaused(t *testing.T) {
 }
 
 func TestErrorChanIsolation(t *testing.T) {
-	// Regression test for issue #287: panic: send on closed channel.
+	// Regression test for issue panic: send on closed channel.
 	//
 	// gouroboros closes whichever error channel it is given during connection
 	// shutdown. Passing the same shared errorChan to every connection means

--- a/main_test.go
+++ b/main_test.go
@@ -224,10 +224,7 @@ func TestErrorChanIsolation(t *testing.T) {
 		go func() {
 			defer close(done)
 			for err := range connErrChan {
-				select {
-				case sharedErrChan <- err:
-				default:
-				}
+				sharedErrChan <- err
 			}
 		}()
 		connErrChan <- fmt.Errorf("error from connection %d", id)

--- a/main_test.go
+++ b/main_test.go
@@ -204,6 +204,45 @@ func TestTogglePaused(t *testing.T) {
 	}
 }
 
+func TestErrorChanIsolation(t *testing.T) {
+	// Regression test for issue #287: panic: send on closed channel.
+	//
+	// gouroboros closes whichever error channel it is given during connection
+	// shutdown. Passing the same shared errorChan to every connection means
+	// the first shutdown closes it, and the second connection panics when it
+	// tries to send on the now-closed channel.
+	//
+	// The fix gives each connection its own connErrChan and relays errors into
+	// the shared channel. This test verifies that pattern: two simulated
+	// connection lifecycles must not panic and must relay their errors.
+
+	sharedErrChan := make(chan error, 10)
+
+	simulateConnection := func(id int) {
+		connErrChan := make(chan error, 10)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for err := range connErrChan {
+				select {
+				case sharedErrChan <- err:
+				default:
+				}
+			}
+		}()
+		connErrChan <- fmt.Errorf("error from connection %d", id)
+		close(connErrChan) // gouroboros closes this on shutdown
+		<-done             // wait for relay goroutine to finish
+	}
+
+	simulateConnection(1)
+	simulateConnection(2) // would panic before the fix
+
+	if len(sharedErrChan) != 2 {
+		t.Errorf("expected 2 relayed errors, got %d", len(sharedErrChan))
+	}
+}
+
 func TestLogBuffer_Write(t *testing.T) {
 	lb := &LogBuffer{maxLines: 3}
 


### PR DESCRIPTION
1. Made changes by fixing shared gouroboros error channel reuse by giving each connection its own error channel and relaying errors to the app-level channel.
2. It prevents closed-channel panics when connections shut down and gouroboros closes its per-connection channel.
3. Explicitly closes each connection after fetching sizes and transactions so teardown is controlled and predictable.
4. Added TestErrorChanIsolation to verify each gouroboros connection uses its own per-connection error channel where it ensures a closed connection channel does not closethe shared app-level error channel across refreshes.

After the fix, txtop was connecting to local cardano node through the node-to-client protocol, it was successfully fetching LocalTxMonitor.GetSizes() and repeatedly calls LocalTxMonitor.NextTx() to fetch the raw pending transactions & able to classify them.

<img width="1701" height="1040" alt="Screenshot 2026-06-02 at 12 54 50 PM" src="https://github.com/user-attachments/assets/60a859b6-8abe-47b6-a1a9-ff3de4b7ccfc" />

Closes #287 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give each `ouroboros` connection its own buffered error channel and relay to the app-level channel to prevent closed-channel panics and dropped async errors (closes #287). Start the relay only after a successful connect to avoid goroutine leaks, and close each connection after fetching sizes and transactions.

<sup>Written for commit d82ea6e2b177ad8406ef4c2593eb5714960a2b5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/txtop/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced connection resource management and cleanup.

* **Tests**
  * Added test coverage for multi-connection error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->