### PR TITLE
fix: legend grid alignment

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rivo/tview"
+	"github.com/rivo/uniseg"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,6 +108,11 @@ var (
 	sortMu        sync.RWMutex
 	currentSortBy string = "size"
 )
+
+type legendItem struct {
+	icon  string
+	label string
+}
 
 // Atomic helpers for paused variable
 func isPaused() bool {
@@ -585,39 +591,86 @@ func updateFooterText(paused bool, sortBy string) string {
 	)
 }
 
+func padDisplayWidth(s string, width int) string {
+	displayWidth := uniseg.StringWidth(s)
+	if displayWidth >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-displayWidth)
+}
+
+func buildLegendText() string {
+	const (
+		iconWidth  = 2
+		labelWidth = 10
+		columnGap  = "  "
+		prefix     = " Legend: "
+	)
+	itemRows := [][]legendItem{
+		{
+			{icon: "🏹", label: "Dexhunter"},
+			{icon: "🚰", label: "DripDropz"},
+			{icon: "👁️", label: "Indigo"},
+			{icon: "🦛", label: "JPGstore"},
+			{icon: "💧", label: "Liqwid"},
+			{icon: "🐱", label: "Minswap"},
+		},
+		{
+			{icon: "🅾️", label: "Optim"},
+			{icon: "💦", label: "Splash"},
+			{icon: "🍨", label: "Sundae"},
+			{icon: "🦭", label: "SealVM"},
+			{icon: "🦸", label: "Wingriders"},
+		},
+		{
+			{icon: "⚡", label: "Strike"},
+			{icon: "🥩", label: "Staking"},
+			{icon: "🏊", label: "SPOs"},
+			{icon: "🏛️", label: "Governance"},
+			{icon: "💲", label: "AdaHandle"},
+		},
+	}
+
+	columns := 0
+	for _, itemRow := range itemRows {
+		if len(itemRow) > columns {
+			columns = len(itemRow)
+		}
+	}
+
+	rows := make([]string, 0, len(itemRows))
+	for _, itemRow := range itemRows {
+		rowItems := make([]string, 0, columns)
+		for _, item := range itemRow {
+			rowItems = append(
+				rowItems,
+				fmt.Sprintf(
+					"%s %s",
+					padDisplayWidth(item.icon, iconWidth),
+					padDisplayWidth(item.label, labelWidth),
+				),
+			)
+		}
+		rows = append(rows, strings.Join(rowItems, columnGap))
+	}
+
+	for i := range rows {
+		if i == 0 {
+			rows[i] = prefix + "[white]" + rows[i]
+			continue
+		}
+		rows[i] = strings.Repeat(" ", len(prefix)) + rows[i]
+	}
+	return strings.Join(rows, "\n")
+}
+
 func setupUI() {
 	headerText.SetText(fmt.Sprintln(" > txtop -", GetVersionString()))
 	sortMu.RLock()
 	sortBy := currentSortBy
 	sortMu.RUnlock()
 	footerText.SetText(updateFooterText(false, sortBy))
-	legendText.SetText(
-		fmt.Sprintf(" Legend: [white]%s\n %s\n %s",
-			fmt.Sprintf("%12s %12s %12s %12s %12s %12s",
-				"🏹 Dexhunter",
-				"🚰 DripDropz",
-				"👁️ Indigo",
-				"🦛 JPGstore",
-				"💧 Liqwid",
-				"🐱 Minswap",
-			),
-			// Text formatting the wrong way for the win
-			fmt.Sprintf("%17s %15s %12s %10s %12s",
-				"🅾️ Optim",
-				"💦 Splash",
-				"🍨 Sundae",
-				"🦭 SealVM",
-				"🦸 Wingriders",
-			),
-			fmt.Sprintf("%12s %9s %12s %12s %12s",
-				"⚡ Strike",
-				"🥩 Staking",
-				"🏊 SPOs",
-				"🏛️ Governance",
-				"💲 AdaHandle",
-			),
-		),
-	)
+	legendText.SetText(buildLegendText())
 	flex.SetDirection(tview.FlexRow).
 		AddItem(headerText,
 			1,

--- a/main_test.go
+++ b/main_test.go
@@ -18,8 +18,11 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/rivo/uniseg"
 )
 
 type txInfo struct {
@@ -149,6 +152,49 @@ func TestUpdateFooterText(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func displayIndex(row, needle string) int {
+	index := strings.Index(row, needle)
+	if index == -1 {
+		return -1
+	}
+	return uniseg.StringWidth(row[:index])
+}
+
+// TestBuildLegendTextAlignsGrid verifies that labels in the same legend column
+// start at the same visible terminal position across all rows.
+func TestBuildLegendTextAlignsGrid(t *testing.T) {
+	legend := strings.ReplaceAll(buildLegendText(), "[white]", "")
+	rows := strings.Split(legend, "\n")
+	if len(rows) != 3 {
+		t.Fatalf("buildLegendText() returned %d rows, want 3", len(rows))
+	}
+
+	labelRows := [][]string{
+		{"Dexhunter", "DripDropz", "Indigo", "JPGstore", "Liqwid", "Minswap"},
+		{"Optim", "Splash", "Sundae", "SealVM", "Wingriders"},
+		{"Strike", "Staking", "SPOs", "Governance", "AdaHandle"},
+	}
+
+	expectedLabelPositions := make([]int, len(labelRows[0]))
+	for i, label := range labelRows[0] {
+		expectedLabelPositions[i] = displayIndex(rows[0], label)
+	}
+
+	for rowIndex, labels := range labelRows[1:] {
+		for columnIndex, label := range labels {
+			got := displayIndex(rows[rowIndex+1], label)
+			if got != expectedLabelPositions[columnIndex] {
+				t.Errorf(
+					"label %q starts at display column %d, want %d",
+					label,
+					got,
+					expectedLabelPositions[columnIndex],
+				)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
1. Replaced hard-coded legend spacing with structured legend rows.
2. Fixed the legend so the icons and text line up neatly.
3. Handled emoji spacing so different icons don’t break the layout.
4. Added a unit-test to make sure the legend stays aligned.

After making the changes, the legend grid alignment is correctly aligned

<img width="3402" height="2076" alt="image" src="https://github.com/user-attachments/assets/6ac26868-e5e8-4dc8-8912-1a804cfcd9d3" />


Closes #327 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the legend grid in txtop so icons and labels line up across rows, including correct emoji widths. Replaces hard‑coded spacing with a display‑width aware layout and adds a test to prevent regressions (closes #327).

- **Bug Fixes**
  - Build legend from structured rows with fixed column widths based on display width.
  - Handle emoji and mixed‑width glyphs using `uniseg.StringWidth`.
  - Use the new legend builder in the footer.

- **Dependencies**
  - Add `github.com/rivo/uniseg` for Unicode display width handling.

<sup>Written for commit 32511cc4883149429bde5276553c6a7644e31a90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/txtop/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legend column alignment to properly account for Unicode character display widths.

* **Tests**
  * Added test coverage for legend alignment verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->