### PR TITLE
feat(txtop): Track Materios L2 transactions

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,20 +231,6 @@ func (c *Config) populateNetworkMagic() error {
 
 func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 	cfg := GetConfig()
-	// gouroboros closes the error channel it's given during shutdown, so we
-	// must never hand it the shared errorChan directly — doing so would close
-	// it and cause a "send on closed channel" panic on the next connection.
-	// Instead give each connection its own channel and relay errors out.
-	connErrorChan := make(chan error, 10)
-	oConn, err := ouroboros.NewConnection(
-		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
-		ouroboros.WithErrorChan(connErrorChan),
-		ouroboros.WithNodeToNode(false),
-		ouroboros.WithKeepAlive(true),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failure creating ouroboros connection: %w", err)
-	}
 	retries := int(cfg.App.Retries)
 	var lastErr error
 	for attempt := 0; attempt <= retries; attempt++ {
@@ -262,6 +248,19 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 			)
 			time.Sleep(delay)
 		}
+		// gouroboros closes the error channel it's given during shutdown, so we
+		// must never hand it the shared errorChan directly. A fresh connection
+		// per retry also avoids re-dialing a half-open connection after EOF.
+		connErrorChan := make(chan error, 10)
+		oConn, err := ouroboros.NewConnection(
+			ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
+			ouroboros.WithErrorChan(connErrorChan),
+			ouroboros.WithNodeToNode(false),
+			ouroboros.WithKeepAlive(true),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failure creating ouroboros connection: %w", err)
+		}
 		if cfg.Node.Address != "" && cfg.Node.Port > 0 {
 			err = oConn.Dial(
 				"tcp",
@@ -278,6 +277,7 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 					attempt,
 				)
 				lastErr = err
+				oConn.Close()
 				continue
 			}
 		} else if cfg.Node.SocketPath != "" {
@@ -285,9 +285,11 @@ func GetConnection(errorChan chan error) (*ouroboros.Connection, error) {
 			if err != nil {
 				slog.Warn("Failed to connect via UNIX socket", "path", cfg.Node.SocketPath, "error", err, "attempt", attempt)
 				lastErr = err
+				oConn.Close()
 				continue
 			}
 		} else {
+			oConn.Close()
 			return nil, errors.New("specify either the UNIX socket path or the address/port")
 		}
 		slog.Info("Successfully connected to node")
@@ -354,6 +356,9 @@ func GetTransactions(oConn *ouroboros.Connection) string {
 		// Check if Tx has metadata and compare against our list
 		if tx.Metadata() != nil {
 			mdCbor := tx.Metadata().Cbor()
+			if isMateriosMetadata(tx.Metadata()) {
+				icon = "Ⓜ️"
+			}
 			var msgMetadata models.Cip20Metadata
 			_ = cbor.Unmarshal(mdCbor, &msgMetadata)
 			if msgMetadata.Num674.Msg != nil {
@@ -565,6 +570,57 @@ func GetTransactions(oConn *ouroboros.Connection) string {
 	return sb.String()
 }
 
+func isMetaInt(m lcommon.TransactionMetadatum, value int64) bool {
+	metaInt, ok := m.(lcommon.MetaInt)
+	return ok && metaInt.Value != nil && metaInt.Value.Int64() == value
+}
+
+func isMetaText(m lcommon.TransactionMetadatum, value string) bool {
+	metaText, ok := m.(lcommon.MetaText)
+	return ok && metaText.Value == value
+}
+
+func isMateriosMetadata(m lcommon.TransactionMetadatum) bool {
+	metaMap, ok := m.(lcommon.MetaMap)
+	if !ok {
+		return false
+	}
+	for _, pair := range metaMap.Pairs {
+		if isMetaInt(pair.Key, 8746) && hasMateriosMarker(pair.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMateriosMarker(m lcommon.TransactionMetadatum) bool {
+	switch meta := m.(type) {
+	case lcommon.MetaList:
+		for _, item := range meta.Items {
+			if hasMateriosMarker(item) {
+				return true
+			}
+		}
+	case lcommon.MetaMap:
+		hasProtocolKey := false
+		hasMateriosValue := false
+		for _, pair := range meta.Pairs {
+			switch {
+			case isMetaText(pair.Key, "k") && isMetaText(pair.Value, "p"):
+				hasProtocolKey = true
+			case isMetaText(pair.Key, "v") && isMetaText(pair.Value, "materios"):
+				hasMateriosValue = true
+			default:
+				if hasMateriosMarker(pair.Value) {
+					return true
+				}
+			}
+		}
+		return hasProtocolKey && hasMateriosValue
+	}
+	return false
+}
+
 func initializeData(errorChan chan error) {
 	oConn, err := GetConnection(errorChan)
 	if err != nil {
@@ -628,6 +684,7 @@ func buildLegendText() string {
 			{icon: "🏊", label: "SPOs"},
 			{icon: "🏛️", label: "Governance"},
 			{icon: "💲", label: "AdaHandle"},
+			{icon: "Ⓜ️", label: "Materios"},
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"fmt"
+	"math/big"
 	"math/rand"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
 
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/rivo/uniseg"
 )
 
@@ -175,7 +177,7 @@ func TestBuildLegendTextAlignsGrid(t *testing.T) {
 	labelRows := [][]string{
 		{"Dexhunter", "DripDropz", "Indigo", "JPGstore", "Liqwid", "Minswap"},
 		{"Optim", "Splash", "Sundae", "SealVM", "Wingriders"},
-		{"Strike", "Staking", "SPOs", "Governance", "AdaHandle"},
+		{"Strike", "Staking", "SPOs", "Governance", "AdaHandle", "Materios"},
 	}
 
 	expectedLabelPositions := make([]int, len(labelRows[0]))
@@ -195,6 +197,74 @@ func TestBuildLegendTextAlignsGrid(t *testing.T) {
 				)
 			}
 		}
+	}
+}
+
+// TestIsMateriosMetadata verifies detection of Materios Cardano metadata
+// without requiring a live node or mempool transaction.
+func TestIsMateriosMetadata(t *testing.T) {
+	materiosMetadata := lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+		{
+			Key: lcommon.MetaInt{Value: big.NewInt(8746)},
+			Value: lcommon.MetaList{Items: []lcommon.TransactionMetadatum{
+				lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+					{
+						Key:   lcommon.MetaText{Value: "k"},
+						Value: lcommon.MetaText{Value: "p"},
+					},
+					{
+						Key:   lcommon.MetaText{Value: "v"},
+						Value: lcommon.MetaText{Value: "materios"},
+					},
+				}},
+			}},
+		},
+	}}
+
+	tests := []struct {
+		name     string
+		metadata lcommon.TransactionMetadatum
+		expected bool
+	}{
+		{
+			name:     "materios label and marker",
+			metadata: materiosMetadata,
+			expected: true,
+		},
+		{
+			name: "same marker under different label",
+			metadata: lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+				{
+					Key:   lcommon.MetaInt{Value: big.NewInt(674)},
+					Value: materiosMetadata.Pairs[0].Value,
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "materios label without marker",
+			metadata: lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+				{
+					Key: lcommon.MetaInt{Value: big.NewInt(8746)},
+					Value: lcommon.MetaMap{Pairs: []lcommon.MetaPair{
+						{
+							Key:   lcommon.MetaText{Value: "v"},
+							Value: lcommon.MetaText{Value: "other"},
+						},
+					}},
+				},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isMateriosMetadata(tt.metadata)
+			if result != tt.expected {
+				t.Errorf("isMateriosMetadata() = %v, want %v", result, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
1. Using this transaction metadata (https://cexplorer.io/tx/b2b55a984af345b3ae758d7c92ee033e3066b24c17b7b1755f07a30e9bababf3?tab=metadata), I have made changes to detect materios transactions by Cardano metadata label 8746.
2. For any of the pending transactions from mempool if it is detected as materios then i am showing it with icon 'M' and added the icon to the legend as well.
3. Added a unit test for materios metadata detection using the above transaction metadata as sample.
4. I have fixed the tcp retry behavior by creating a fresh ouroboros connection per retry attempt. (This is not related to this issue but i ran into some connection errors when trying to connect cardano node).

Closes #315 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect Materios L2 transactions using Cardano metadata label 8746 and mark them with an Ⓜ️ icon in the mempool and legend. Also fixes retry stability by creating a new `ouroboros` connection on each attempt.

- **New Features**
  - Detect Materios tx via label 8746 with marker k: "p", v: "materios".
  - Show Ⓜ️ for matching pending tx; add "Materios" to the legend.
  - Add unit tests for the detection logic.

- **Bug Fixes**
  - Create a fresh `ouroboros` connection per retry to avoid closed error channels and half-open reconnects.

<sup>Written for commit d380a2e149bde8e45a3c442b80824fae4ecda64b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/txtop/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented detection of Materios transactions with dedicated Ⓜ️ icon display
  * Updated UI legend to include Materios transaction type

* **Bug Fixes**
  * Improved connection retry handling to explicitly close failed socket connections before subsequent retry attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->