### PR TITLE
chore: require Go 1.25 minimum

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6 https://github.com/actions/setup-go/releases/tag/v6
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/txtop
 
-go 1.24.0
+go 1.25.7
 
-toolchain go1.24.4
+toolchain go1.25.8
 
 require (
 	github.com/blinklabs-io/cardano-models v0.7.0


### PR DESCRIPTION
## Summary

Go 1.24 is end-of-life. This bumps txtop to a **Go 1.25 minimum** and aligns its CI with the rest of the Blink Labs Go repos (gouroboros, adder, bursa, …):

- `go.mod`: `go 1.24.0` → `go 1.25.7`, `toolchain go1.24.4` → `toolchain go1.25.8`
- `go-test.yml`: test matrix `[1.24.x, 1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `nilaway.yml`: `1.25.x` → `1.26.x`
- `publish.yml`: `1.24.x` → `1.26.x`

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26. No source changes were required; `go.sum` is unchanged.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise minimum Go version to 1.25 and align CI to build/lint on 1.26 and test across 1.25.x/1.26.x; no code changes. Updates `go.mod` to `go 1.25.7` and `toolchain go1.25.8`, and bumps GitHub Actions (`go-test`, `golangci-lint`, `nilaway`, `publish`) to drop 1.24.

<sup>Written for commit 37c63b5ae0bf562cc6eb5925bf0545bab46b6a06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/txtop/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version requirements to 1.25.x and 1.26.x for testing, linting, and building. This ensures the project remains compatible with the latest Go releases and benefits from toolchain improvements in newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->