### PR TITLE
chore: migrate workflows to reusable actions repo patterns

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,36 +1,18 @@
-name: Docker CI
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Docker CI"
 
 on:
   pull_request:
-    branches: ['main']
-    paths: ['Dockerfile','*.go','go.*','.github/workflows/ci-docker.yml']
-
-env:
-  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/txtop
-
-permissions:
-  contents: read
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - '*.go'
+      - go.*
+      - .github/workflows/ci-docker.yml
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: '0'
-          persist-credentials: false
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4 https://github.com/docker/setup-qemu-action/releases/tag/v4
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4 https://github.com/docker/setup-buildx-action/releases/tag/v4
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6 https://github.com/docker/metadata-action/releases/tag/v6
-        with:
-          images: ${{ env.GHCR_IMAGE_NAME }}
-      - name: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7 https://github.com/docker/build-push-action/releases/tag/v7
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-ci-docker.yml@main
+    with:
+      image-name: blinklabs-io/txtop

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,19 +1,9 @@
-# The below is pulled from upstream and slightly modified
-# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
-
-name: Conventional Commits
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Conventional Commits"
 
 on:
   pull_request:
 
 jobs:
-  build:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          persist-credentials: false
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-conventional-commits.yml@main

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,30 +1,14 @@
-name: go-test
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "go-test"
 
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  go-test:
-    name: go-test
-    strategy:
-      matrix:
-        go-version: [1.25.x, 1.26.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6 https://github.com/actions/setup-go/releases/tag/v6
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: go-test
-        run: go test ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-go-test.yml@main

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,25 +1,16 @@
-name: golangci-lint
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "golangci-lint"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
-        with:
-          go-version: 1.26.x
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-golangci-lint.yml@main
+    with:
+      go-version: "1.26.x"

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,27 +1,17 @@
-name: nilaway
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "nilaway"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  nilaway:
-    name: nilaway
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
-        with:
-          go-version: 1.26.x
-      - name: install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
-      - name: run nilaway
-        run: nilaway ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-nilaway.yml@main
+    with:
+      include-pkgs: github.com/blinklabs-io/txtop
+      go-version: "1.26.x"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,180 +1,29 @@
-name: publish
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "publish"
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - main
     tags:
-      - 'v*.*.*'
+      - v*.*.*
 
-concurrency: ${{ github.ref }}
+permissions:
+  actions: write
+  attestations: write
+  checks: write
+  contents: write
+  id-token: write
+  packages: write
+  statuses: write
 
 jobs:
-  create-draft-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      RELEASE_ID: ${{ steps.create-release.outputs.result }}
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 https://github.com/actions/github-script/releases/tag/v9
-        id: create-release
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            try {
-              const response = await github.rest.repos.createRelease({
-                draft: true,
-                generate_release_notes: true,
-                name: process.env.RELEASE_TAG,
-                owner: context.repo.owner,
-                prerelease: false,
-                repo: context.repo.repo,
-                tag_name: process.env.RELEASE_TAG,
-              });
-
-              return response.data.id;
-            } catch (error) {
-              core.setFailed(error.message);
-            }
-
-  build-binaries:
-    strategy:
-      matrix:
-        os: [linux, darwin, freebsd, windows]
-        arch: [amd64, arm64]
-    runs-on: ubuntu-latest
-    needs: [create-draft-release]
-    permissions:
-      actions: write
-      attestations: write
-      checks: write
-      contents: write
-      id-token: write
-      packages: write
-      statuses: write
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: '0'
-          persist-credentials: false
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6 https://github.com/actions/setup-go/releases/tag/v6
-        with:
-          go-version: 1.26.x
-      - name: Build binary
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
-      - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          _filename=txtop-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
-          if [[ ${{ matrix.os }} == windows ]]; then
-            _filename=${_filename}.exe
-          fi
-          cp txtop ${_filename}
-          curl \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @${_filename} \
-            https://uploads.github.com/repos/${{ github.repository_owner }}/txtop/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
-      - name: Attest binary
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-path: 'txtop'
-
-  build-images:
-    runs-on: ubuntu-latest
-    needs: [create-draft-release]
-    permissions:
-      actions: write
-      attestations: write
-      checks: write
-      contents: write
-      id-token: write
-      packages: write
-      statuses: write
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-        with:
-          fetch-depth: '0'
-          persist-credentials: false
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4 https://github.com/docker/setup-qemu-action/releases/tag/v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4 https://github.com/docker/setup-buildx-action/releases/tag/v4
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4 https://github.com/docker/login-action/releases/tag/v4
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4 https://github.com/docker/login-action/releases/tag/v4
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6 https://github.com/docker/metadata-action/releases/tag/v6
-        with:
-          images: |
-            blinklabs/txtop
-            ghcr.io/${{ github.repository }}
-          tags: |
-            # branch
-            type=ref,event=branch
-            # semver
-            type=semver,pattern={{version}}
-      - name: Build images
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7 https://github.com/docker/build-push-action/releases/tag/v7
-        id: push
-        with:
-          outputs: "type=registry,push=true"
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Attest Docker Hub image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: index.docker.io/blinklabs/txtop
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-      - name: Attest GHCR image
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
-      # Update Docker Hub from README
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5 https://github.com/peter-evans/dockerhub-description/releases/tag/v5
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: blinklabs/txtop
-          readme-filepath: ./README.md
-          short-description: "txtop is a mempool display tool for a Cardano Node"
-
-  finalize-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [create-draft-release, build-binaries, build-images]
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 https://github.com/actions/github-script/releases/tag/v9
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
-                draft: false,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-publish.yml@main
+    secrets:
+      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+    with:
+      binary-name: txtop
+      docker-image: blinklabs/txtop
+      description: "txtop is a mempool display tool for a Cardano Node"
+      go-version: "1.26.x"

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,19 +1,14 @@
-name: Test Issue Close Trigger
-permissions:
-  contents: read
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Test Issue Close Trigger"
+
 on:
   issues:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          echo "Title: $ISSUE_TITLE"
-          echo "Workflow triggered successfully when issue was closed."
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,41 +1,18 @@
-name: Set Project Closed Date
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Set Project Closed Date"
 
 on:
   issues:
-    types: [closed]
-
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
-  set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        env:
-          ISSUE_CLOSED_AT: ${{ github.event.issue.closed_at }}
-        run: |
-          ts="$ISSUE_CLOSED_AT"
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            d=$(date -u +%F)
-          else
-            d=$(date -u -d "$ts" +%F)
-          fi
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}
+    with:
+      closed_at: ${{ github.event.issue.closed_at }}
+      closed_date_field: Closed Date
+      project_url: https://github.com/orgs/blinklabs-io/projects/11


### PR DESCRIPTION
Replaces all inline workflow definitions with wrappers that delegate to reusable workflows in `blinklabs-io/actions`.

## Changes
- `conventional-commits.yml` → `reuseable-conventional-commits.yml@main`
- `go-test.yml` → `reuseable-go-test.yml@main`
- `golangci-lint.yml` → `reuseable-golangci-lint.yml@main` (go-version: 1.26.x)
- `nilaway.yml` → `reuseable-nilaway.yml@main` (include-pkgs: github.com/blinklabs-io/txtop, go-version: 1.26.x)
- `ci-docker.yml` → `reuseable-ci-docker.yml@main` (image-name: blinklabs-io/txtop)
- `publish.yml` → `reuseable-publish.yml@main` (binary-name: txtop, docker-image: blinklabs/txtop, go-version: 1.26.x)
- `test-issue-on-close.yml` → `reuseable-test-issue-on-close.yml@main`
- `update-issue-on-close.yml` → `reuseable-set-project-closed-date.yml@main`

## Testing
Draft PR to verify all CI checks pass before governance sync is enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all GitHub Actions workflows to reusable workflows in `blinklabs-io/actions` to standardize CI and reduce maintenance. This removes duplicated YAML and aligns triggers, tooling, and permissions across the repo.

- **Refactors**
  - Replaced 8 inline workflows with reusable ones: conventional commits, tests, lint, nilaway, Docker CI, publish, and two issue-close automations.
  - Passed required inputs where needed:
    - `golangci-lint`: `go-version: "1.26.x"`
    - `nilaway`: `include-pkgs: github.com/blinklabs-io/txtop`, `go-version: "1.26.x"`
    - `ci-docker`: `image-name: blinklabs-io/txtop`
    - `publish`: `binary-name: txtop`, `docker-image: blinklabs/txtop`, `description` set, `go-version: "1.26.x"`
    - Issue workflows: project URL, closed date field, and `ORG_PROJECT_PAT` secret configured

<sup>Written for commit 8627ff899f96513e1e2d25f3aaa540666e87c75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/txtop/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

